### PR TITLE
fix total memory parsing

### DIFF
--- a/main.py
+++ b/main.py
@@ -77,12 +77,17 @@ def main():
         print(f"  Requests: {requests_str}")
         print("-" * 40)
 
+    # Convert to MiB for legibility
+    # TODO: maybe add automatic human readable dump?
+    total_memory_limits_mib = total_memory_limits // (1024**2)
+    total_memory_requests_mib = total_memory_requests // (1024**2)
+
     # Imprime os totais acumulados de recursos
     print("Total Resources:")
     print(f"  CPU Limits: {total_cpu_limits}m")
-    print(f"  Memory Limits: {total_memory_limits}Mi")
+    print(f"  Memory Limits: {total_memory_limits_mib}Mi")
     print(f"  CPU Requests: {total_cpu_requests}m")
-    print(f"  Memory Requests: {total_memory_requests}Mi")
+    print(f"  Memory Requests: {total_memory_requests_mib}Mi")
 
 # Função para converter valores de CPU em milicpus
 def parse_cpu(cpu_str):
@@ -90,7 +95,7 @@ def parse_cpu(cpu_str):
         return int(cpu_str[:-1])
     return int(float(cpu_str) * 1000)
 
-# Função para converter valores de memória em Mebibytes (Mi)
+# Memory value in bytes
 def parse_memory(memory_str):
     if memory_str.endswith('Ei'):
         return ceil(float(memory_str[:-2]) * 1024**6)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from pick import pick 
 from kubernetes import client, config 
 from kubernetes.client import configuration
+from math import ceil
 
 def main():
     # Carrega contextos do arquivo kube-config
@@ -92,32 +93,32 @@ def parse_cpu(cpu_str):
 # Função para converter valores de memória em Mebibytes (Mi)
 def parse_memory(memory_str):
     if memory_str.endswith('Ei'):
-        return int(float(memory_str[:-2]) * 1024**6)
+        return ceil(float(memory_str[:-2]) * 1024**6)
     elif memory_str.endswith('Pi'):
-        return int(float(memory_str[:-2]) * 1024**5)
+        return ceil(float(memory_str[:-2]) * 1024**5)
     elif memory_str.endswith('Ti'):
-        return int(float(memory_str[:-2]) * 1024**4)
+        return ceil(float(memory_str[:-2]) * 1024**4)
     elif memory_str.endswith('Gi'):
-        return int(float(memory_str[:-2]) * 1024**3)
+        return ceil(float(memory_str[:-2]) * 1024**3)
     elif memory_str.endswith('Mi'):
-        return int(float(memory_str[:-2]) * 1024**2)
+        return ceil(float(memory_str[:-2]) * 1024**2)
     elif memory_str.endswith('Ki'):
-        return int(float(memory_str[:-2]) * 1024)
+        return ceil(float(memory_str[:-2]) * 1024)
     elif memory_str.endswith('E'):
-        return int(float(memory_str[:-1]) * 10**18 / 1024**2)
+        return ceil(float(memory_str[:-1]) * 1000**6)
     elif memory_str.endswith('P'):
-        return int(float(memory_str[:-1]) * 10**15 / 1024**2)
+        return ceil(float(memory_str[:-1]) * 1000**5)
     elif memory_str.endswith('T'):
-        return int(float(memory_str[:-1]) * 10**12 / 1024**2)
+        return ceil(float(memory_str[:-1]) * 1000**4)
     elif memory_str.endswith('G'):
-        return int(float(memory_str[:-1]) * 10**9 / 1024**2)
+        return ceil(float(memory_str[:-1]) * 1000**3)
     elif memory_str.endswith('M'):
-        return int(float(memory_str[:-1]) * 10**6 / 1024**2)
+        return ceil(float(memory_str[:-1]) * 1000**2)
     elif memory_str.endswith('k'):
-        return int(float(memory_str[:-1]) * 10**3 / 1024**2)
+        return ceil(float(memory_str[:-1]) * 1000)
     elif memory_str.endswith('m'):
-        return int(float(memory_str[:-1]) / 1024**2)
-    return int(memory_str)  # If the values are in bytes, convert to MiB
+        return ceil(float(memory_str[:-1]) / 1000)
+    return int(memory_str)
 
 if __name__ == '__main__':
     main() 


### PR DESCRIPTION
keeps the value in mib for now, but the values are kept as bytes until the end to be less error-prone